### PR TITLE
Write groups warning to stderr

### DIFF
--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1430,7 +1430,7 @@ class AMDSMIHelpers():
                 "  • Alternatively, run this command with sudo/admin privileges",
                 ""
             ])
-            print("\n".join(lines))
+            print("\n".join(lines), file=sys.stderr)
             return False
 
         return True


### PR DESCRIPTION
If you run `amd-smi static --json` and attempt to parse the output, but
it produces this warning, you don't get valid json. Instead this warning
should go to stderr.
